### PR TITLE
Update printer-creality-ender3-v3-se-2023.cfg

### DIFF
--- a/printer-creality-ender3-v3-se-2023.cfg
+++ b/printer-creality-ender3-v3-se-2023.cfg
@@ -47,7 +47,7 @@ rotation_distance: 40
 endstop_pin: ~!PA6
 position_endstop: -14
 position_min: -14
-position_max: 230
+position_max: 227
 homing_speed: 80
 
 [tmc2208 stepper_y]
@@ -150,7 +150,7 @@ z_hop_speed: 10
 speed: 120
 horizontal_move_z: 5
 mesh_min: 30,30         # Need to handle head distance with cr-touch (bl_touch)
-mesh_max: 207,215.5     # Max probe range (230-23,230-14.5)
+mesh_max: 207,212.5     # Max probe range (230-23,230-14.5)
 probe_count: 5,5
 algorithm: bicubic
 


### PR DESCRIPTION
Changed [bed_mesh] and [stepper_y] values to stop the Y-axis from crashing into the front of the printer and forcing it to move further than it can.