### PR TITLE
Update printer-creality-ender3-v3-se-2023.cfg

### DIFF
--- a/printer-creality-ender3-v3-se-2023.cfg
+++ b/printer-creality-ender3-v3-se-2023.cfg
@@ -32,7 +32,7 @@ homing_speed: 80
 
 [tmc2208 stepper_x]
 uart_pin: PB12
-run_current: 0.60
+run_current: 0.90
 #hold_current: 0.5
 sense_resistor: 0.150
 #stealthchop_threshold: 999999
@@ -52,7 +52,7 @@ homing_speed: 80
 
 [tmc2208 stepper_y]
 uart_pin: PB13
-run_current: 0.60
+run_current: 0.90
 #hold_current: 0.5
 sense_resistor: 0.150
 #stealthchop_threshold: 999999
@@ -73,7 +73,7 @@ homing_retract_dist: 2.0
 
 [tmc2208 stepper_z]
 uart_pin: PB14
-run_current: 0.8
+run_current: 0.9
 #hold_current: 0.5
 sense_resistor: 0.150
 #stealthchop_threshold: 999999

--- a/printer-creality-ender3-v3-se-2023.cfg
+++ b/printer-creality-ender3-v3-se-2023.cfg
@@ -25,8 +25,8 @@ enable_pin: !PC3
 microsteps: 16
 rotation_distance: 40
 endstop_pin: ~!PA5
-position_endstop: -6
-position_min: -6
+position_endstop: -4
+position_min: -4
 position_max: 230
 homing_speed: 80
 
@@ -45,8 +45,8 @@ enable_pin: !PC3
 microsteps: 16
 rotation_distance: 40
 endstop_pin: ~!PA6
-position_endstop: -14
-position_min: -14
+position_endstop: -17
+position_min: -17
 position_max: 230
 homing_speed: 80
 
@@ -132,8 +132,8 @@ max_z_accel: 100
 [bltouch]
 sensor_pin: ^PC14
 control_pin: PC13
-x_offset: -23.0
-y_offset: -14.5
+x_offset: -31.75
+y_offset: -14.69
 z_offset: 2.65
 speed: 20
 pin_move_time: 0.4


### PR DESCRIPTION
The run_current for the stepper motors was too low, causing layer shifts. I raised the x & y stepper motors to .9, and the z motor to even it out. @0xD34D 